### PR TITLE
Fix assetMap parse error

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ module.exports = {
 
     let assetFileName = null;
     for (let i = 0; i < totalFiles; i++) {
-      if (files[i].match(/^assetMap/i)) {
+      if (files[i].match(/^assetMap.*\.json$/i)) {
         assetFileName = files[i];
         break;
       }


### PR DESCRIPTION
In addons using Embroider, a file assetMap.js is generated upon first build. In subsequent rebuilds this file got selected instead of assetMap.json. The contents of this file is provided to JSON.parse, resulting in a crash.

Previously, this was patch using a try/catch: https://github.com/gynzy/ember-cli-ifa/commit/3c1b72ea73d6ac1e6ab907deb76a28587d4649ef. This commit was discarded in 0.9.7, resulting in the re-introduction of the crash.